### PR TITLE
docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby
+
+VOLUME [ "/data"]
+
+ADD . /data
+
+EXPOSE 4000
+
+WORKDIR "/data"
+
+RUN bundle install
+
+CMD [ "jekyll", "serve" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby
+FROM ruby:alpine
 
 VOLUME [ "/data"]
 
@@ -8,6 +8,7 @@ EXPOSE 4000
 
 WORKDIR "/data"
 
-RUN bundle install
+RUN apk update && apk upgrade && apk add ruby-dev build-base && \
+    bundle install
 
 CMD [ "jekyll", "serve" ]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Jekyll website for cevo.com.au
 # How to develop (docker)
 If you don't want to install Ruby and instead test the site in docker container:
 ```
-docker-compose run cevo-web
+docker-compose up cevo-web
 ```
 This should build the docker image and run the server at http://localhost:4000/.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Jekyll website for cevo.com.au
 
 [ ![Codeship Status for cevoaustralia/cevoaustralia.github.io](https://codeship.com/projects/8fa2b1e0-44d0-0134-47ad-02154be91b77/status?branch=master)](https://codeship.com/projects/168509)
 
+# How to develop (docker)
+If you don't want to install Ruby and instead test the site in docker container:
+```
+docker-compose run cevo-web
+```
+This should build the docker image and run the server at http://localhost:4000/.
+
 # How to develop
 
 You need to have:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Jekyll website for cevo.com.au
 # How to develop (docker)
 If you don't want to install Ruby and instead test the site in docker container:
 ```
-docker-compose up cevo-web
+docker-compose build
+docker-compose up
 ```
 This should build the docker image and run the server at http://localhost:4000/.
 

--- a/_config.yml
+++ b/_config.yml
@@ -25,3 +25,4 @@ gems: [jekyll-paginate]
 paginate: 4
 paginate_path: "blog/page:num"
 future: true
+host: 0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  cevo-web:
+    build: .
+    volumes:
+      - .:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,5 +2,7 @@ version: '2'
 services:
   cevo-web:
     build: .
+    ports:
+      - "4000:4000/tcp"
     volumes:
       - .:/data


### PR DESCRIPTION
allow using ```docker-compose up cevo-web``` to test the website without the need to install Ruby on the host