### PR TITLE
Slowed down testimonials to be easier to read

### DIFF
--- a/javascripts/app.js
+++ b/javascripts/app.js
@@ -829,6 +829,7 @@ jQuery(document).foundation();
         autoplay: true,
         dots: show_dots,
         speed: 1500,
+        autoplaySpeed: 20000,
         pauseOnHover: true,
         pauseOnFocus: true,
         arrows: false


### PR DESCRIPTION
Slowed down testimonials to stay for 20 seconds to make it easier to read. Please verify and validate it at http://beta.cevo.com.au