### PR TITLE
changed profile sort by date instead of number and tabcorp testimonial added 

### DIFF
--- a/_data/staff.yml
+++ b/_data/staff.yml
@@ -1,5 +1,5 @@
 - name: Geoff Rohrsheim
-  sort: 1
+  sort: 2015-02-01
   position: Executive Director
   desc:
     Geoff is a former EY Entrepreneur of the Year winner for the southern
@@ -12,7 +12,7 @@
     - icon_class: fa fa-linkedin
       url: https://au.linkedin.com/in/geoffrohrsheim
 - name: Hannah Browne
-  sort: 2
+  sort: 2015-03-01
   position: General Manager
   desc:
     Hannah Browne is a passionate, opinionated deal maker, and the General Manager of Cevo.
@@ -25,7 +25,7 @@
       url: https://au.linkedin.com/in/hannahbrowne
 
 - name: Veronica Finarelli
-  sort: 7
+  sort: 2015-08-01
   position: People and Culture
   desc:
     Veronica is HR qualified and passionate about finding curious, clever people to join the ever growing Cevo team. Veronica has worked in many different organisations and industries however loves working in forward thinking, agile companies.
@@ -37,7 +37,7 @@
       url: https://au.linkedin.com/in/veronicafinarelli
 
 - name: Richard Busso
-  sort: 17
+  sort: 2016-10-01
   position: Client Solutions Executive
   desc:
     Richard Busso is a connector within the industry who builds strong long lasting relationships and is the Client Solutions Executive at Cevo.
@@ -50,7 +50,7 @@
   #     url:
 
 - name: Orlando Erazo
-  sort: 3
+  sort: 2015-05-01
   position: Continuous Delivery Advocate
   desc:
     Orlando spent 13 years working in software development, he then decided to focus on continuous delivery
@@ -63,7 +63,7 @@
       url: https://au.linkedin.com/in/orlando-erazo-68a11026
 
 - name: Steve Mactaggart
-  sort: 12
+  sort: 2016-07-01
   position: Application Delivery Evangineer
   desc:
     Steve loves helping businesses deliver the best solution for their customers in a way that fits both their timelines and their customer needs.
@@ -79,7 +79,7 @@
       url: https://www.twitter.com/stevemac
 
 - name: David Walters
-  sort: 15
+  sort: 2016-09-16
   position: Reliability Consultant
   desc:
     David has been a passionate technologist for several years and has extensive experience in building software for a wide range of businesses.
@@ -93,7 +93,7 @@
       url: https://www.twitter.com/whatbirdisthat
 
 - name: Adam Nowotny
-  sort: 4
+  sort: 2015-05-10
   position: Software consultant and open-source advocate
   desc:
     Adam started programming after getting his first 8-bit computer Atari 800XL at the age of seven. He has worked in software delivery teams as a developer, agile coach and technical lead for over 20 clients in Australia, Ireland, Poland, China, Brazil and India.
@@ -105,7 +105,7 @@
       url: https://www.twitter.com/adam_nowotny
 
 - name: Robert Rocco
-  sort: 6
+  sort: 2015-07-01
   position: Infrastructure Automation and Reliability Engineer
   desc:
     Robert Rocco is highly motivated and goal driven member of the team at Cevo.  He is continuously seeking knowledge and thrives on challenges.  Finding the best solution for a problem is one of his main focuses, believing you should always be looking to improve.
@@ -117,7 +117,7 @@
 #       url: http://facebook.com
 
 - name: Andy Shaw
-  sort: 5
+  sort: 2015-06-01
   position: Automation Artificer
   desc:
     Andy was once a developer before he became fascinated with devops and being able to automate All The Things. Since then, he's been enjoying using some of the new technologies emerging in the devops space alongside proven technologies to solve a diverse range of problems.
@@ -129,7 +129,7 @@
   #     url: http://facebook.com
 
 - name: Karel Malbroukou Moendzenahou
-  sort: 8
+  sort: 2015-09-01
   position: Delivery and Continuous Improvement Consultant
   desc:
     Karel is a consultant who provides leadership and delivery of operations best practices, cloud automation solutions and devops transformation.
@@ -142,7 +142,7 @@
       url: https://twitter.com/labrute974
 
 - name: Trent Hornibrook
-  sort: 9
+  sort: 2016-06-05
   position: Infrastructure Coder
   desc:
     Trent Hornibrook is a passionate engineer that wants to reduce the cycle from ‘idea’ to ‘cash’. Having a history of Infrastructure Operations, MySQL DBA and Agile Delivery, Trent loves simplifying complex problems and identifying ways to deliver value sooner.
@@ -154,7 +154,7 @@
       url: https://www.twitter.com/mysqldbahelp
 
 - name: Owen Chung
-  sort: 10
+  sort: 2016-06-12
   position: Automation Engineer
   desc:
     Owen Chung is a passionate technologist in the game since the turn of the century. He believes tech is an expression of culture. Quality tech reflects a quality culture. His mission is to help tech builders, makers and creators be their best wielding his devops superpowers to drive this cultural change.
@@ -164,7 +164,7 @@
       url: https://au.linkedin.com/in/owen-chung-27b2bb11
 
 - name: Colin Panisset
-  sort: 11
+  sort: 2016-06-30
   position: Director, Transformation and Delivery
   desc:
     Colin brings his history of operational excellence together with a desire to improve delivery practices to drive business value through improving culture, empathy, automation and technical excellence. He has a knack for understanding and explaining complex systems, and has presented at events like AWS Summits, Devops Days, and many meetups.
@@ -176,7 +176,7 @@
       url: https://www.twitter.com/nonspecialist
 
 - name: Melissa Ngau
-  sort: 13
+  sort: 2016-08-01
   position: Quality Analysis Consultant
   desc:
     Melissa began her career in testing and quickly discovered the value of building quality in from inception.
@@ -190,7 +190,7 @@
     #   url:
 
 - name: Nikita Gandhi
-  sort: 14
+  sort: 2016-09-01
   position: Infrastructure Automation And Continuous Delivery Consultant
   desc:
     Nikita is a passionate technologist looking to assist organisations in their journey of agile software adoption.
@@ -203,7 +203,7 @@
   #     url:
 
 - name: Simon Bond
-  sort: 16
+  sort: 2016-09-30
   position: Business Designer
   desc: Simon can be found playing Product Owner, Business Analysis, IM/PM or Agile Coaching roles. He is on a perpetual journey to drag IT closer to "the business" and EVERYONE closer to their customers. Simon is an efficiency addict who loves helping teams shift the dial from a focus on outputs to a focus on measurable business outcomes.
   avatar: images/staff/simon_bond.jpg
@@ -216,7 +216,7 @@
   #     url: http://facebook.com
 
 - name: Henrik Axelsson
-  sort: 18
+  sort: 2016-11-01
   position: Business Solutions Consultant
   desc: Henrik has worked across a large variety of technology roles before landing at Business Analysis. With a solid background in software development, Henrik has acquired a rich understanding for both the technical and operational aspects of project delivery. This experience has given him a keen eye for striking the delicate balance between technical and operational trade offs.
   avatar: images/staff/henrik_axelsson.jpg
@@ -229,7 +229,7 @@
   #     url: http://facebook.com
 
 - name: Jamie Potter
-  sort: 0
+  sort: 2015-01-01
   position: Executive Director
   desc: Jamie works behind the scenes at Cevo ensuring the business is ready for the predicted growth.
         <br/><br/>He’s been involved in numerous technology start-ups, expansions and exits. He uses his experience to help Cevo build scale into its delivery and operations.

--- a/_posts/2016-08-08-migrating-to-aws.markdown
+++ b/_posts/2016-08-08-migrating-to-aws.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Migrating to AWS"
-description: How MYOB benefited from migrating to Amazon Web Services to automate infrastructure, provide self-servicing & reduce costs
+description: How MYOB benefited from migrating to AWS to automate infrastructure, provide self-servicing & reduce costs
 date:   2016-08-08
 categories:
   - devops


### PR DESCRIPTION
**changes are**
- Changed the profile to be sorted by a date instead of number 
- Sort order should the same as what is in production 
- Colin added tabcorp testimonial

**impact**
- No visible change as our profiles will be sorted in the same order as current production
- Tabcorp testimonial appears in the testimonial section of the website 
![screen shot 2016-12-16 at 3 30 05 pm](https://cloud.githubusercontent.com/assets/1217359/21251761/8f3edb10-c3a4-11e6-9ca5-e9b3926f6181.png)

Please verify and validate it's all ship shape to cruise out into the production harbour. 