### PR TITLE
Adjust careers email to use the careers@ address

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,10 @@ sales:
   phone: 1300 518 265
   email: sales@cevo.com.au
 
+careers:
+  phone: 1300 518 265
+  email: careers@cevo.com.au
+
 # Build settings
 exclude: [Gemfile, Gemfile.lock, README.md, TODO.md]
 markdown: kramdown

--- a/careers.html
+++ b/careers.html
@@ -97,9 +97,9 @@ section_id: careers
           <p>{{ site.sydney_address }}</p>
 
           <h4>Our Phone:</h4>
-          <p>{{ site.sales.phone }}</p>
+          <p>{{ site.careers.phone }}</p>
           <h4>Our Email:</h4>
-          <p>{{ site.sales.email }}</p>
+          <p>{{ site.careers.email }}</p>
         </div>
       </div>
 


### PR DESCRIPTION
Make use of the specific careers-at-cevo.com.au email address for the Careers page only. Phone number is not changed.