### PR TITLE
Updated all blog posts to share new images as valid twitter cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,22 @@ $ bundle exec jekyll build --watch
 #    watched for changes, and regenerated automatically.
 ```
 
+### How to build the beta site
+
+To ensure that the correct absolute URL's are generated for the `beta.cevo.com.au` site, you need
+to specify an override file at build time to include the additional beta configuration.
+
+```
+# bundle exec jekyll build --config _config.yml,_config_beta.yml
+```
+
+### How to build the production site
+
+To ensure that the correct absolute URL's are generated for the `www.cevo.com.au` site, you need
+to specify an override file at build time to include the additional production configuration.
+
+```
+# bundle exec jekyll build --config _config.yml,_config_production.yml
+```
 
 [f0caf124]: https://jekyllrb.com/ "Jekyll"

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ description: > # this means to ignore newlines until "baseurl:"
   Automation
   Infrastructure
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://beta.cevo.com.au" # the base hostname & protocol for your site
+url: "https://www.cevo.com.au" # the base hostname & protocol for your site
 twitter_url: https://twitter.com/cevoaustralia
 linkedin_url: https://www.linkedin.com/company/cevoaustralia
 youtube_url: https://www.youtube.com/channel/UCeWwnMuG8a93Y5jf3ak2HIw

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,8 @@ description: > # this means to ignore newlines until "baseurl:"
   Automation
   Infrastructure
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "https://www.cevo.com.au" # the base hostname & protocol for your site
+# URL configuration is managed at build time through the use of _config_<ENV>.yml files
+# url: "https://www.cevo.com.au" # the base hostname & protocol for your site
 twitter_url: https://twitter.com/cevoaustralia
 linkedin_url: https://www.linkedin.com/company/cevoaustralia
 youtube_url: https://www.youtube.com/channel/UCeWwnMuG8a93Y5jf3ak2HIw

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ description: > # this means to ignore newlines until "baseurl:"
   Automation
   Infrastructure
 baseurl: "" # the subpath of your site, e.g. /blog/
-# url: "http://yourdomain.com" # the base hostname & protocol for your site
+url: "http://beta.cevo.com.au" # the base hostname & protocol for your site
 twitter_url: https://twitter.com/cevoaustralia
 linkedin_url: https://www.linkedin.com/company/cevoaustralia
 youtube_url: https://www.youtube.com/channel/UCeWwnMuG8a93Y5jf3ak2HIw

--- a/_config_beta.yml
+++ b/_config_beta.yml
@@ -1,0 +1,1 @@
+url: "http://beta.cevo.com.au" # the base hostname & protocol for your site

--- a/_config_production.yml
+++ b/_config_production.yml
@@ -1,0 +1,1 @@
+url: "https://www.cevo.com.au" # the base hostname & protocol for your site

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,7 +24,7 @@
   {% endif %}
   {% if page.url %}
   <meta name="twitter:url" content="{{ site.url }}{{ page.url }}">
-  <meta property='og:url' content=" {{ site.url }}{{ page.url }}" />
+  <meta property='og:url' content="{{ site.url }}{{ page.url }}" />
   {% endif %}
   {% if page.description %}
   <meta name="twitter:description" content="{{ page.description }}">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,6 @@
   {% css fontello %}
   {% css font-awesome %}
 
-  <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@cevoaustralia">
   {% if page.twittercreator %}
   <meta name="twitter:creator" content="@{{ page.twittercreator }}">
@@ -35,10 +34,12 @@
   <meta property='og:description' content="{{ site.description }}"/>
   {% endif %}
   {% if page.thumbnail %}
-  <meta name="twitter:image" content="{{ site.url }}/images/{{ page.thumbnail }}">
-  <meta name="twitter:image:src" content="{{ site.url }}/images/{{ page.thumbnail }}">
-  <meta property='og:image' content="{{ site.url }}/images/{{ page.thumbnail }}"/>
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="{{ site.url }}{% asset_path {{page.thumbnail}} %}">
+  <meta name="twitter:image:src" content="{{ site.url }}{% asset_path {{page.thumbnail}} %}">
+  <meta property='og:image' content="{{ site.url }}{% asset_path {{page.thumbnail}} %}"/>
   {% else %}
+  <meta name="twitter:card" content="summary">
   <meta name="twitter:image" content="https://cevo.com.au/images/cevo-swoosh.png">
   <meta name="twitter:image:src" content="https://cevo.com.au/images/cevo-swoosh.png">
   <meta property='og:image' content="{{ site.url }}/images/cevo-swoosh.png"/>
@@ -46,7 +47,7 @@
 
   {% javascript libs %}
   {% javascript ga %}
- 
+
   <script>
     // terrificjs bootstrap
     (function($) {

--- a/_posts/2015-05-03-The-Consul-of-Elders.markdown
+++ b/_posts/2015-05-03-The-Consul-of-Elders.markdown
@@ -10,6 +10,8 @@ tags:
   - consul
 author: Michael Richardson
 images: blog/how-consul-and-docker-work-together.png
+thumbnail: blog/how-consul-and-docker-work-together.png
+
 excerpt: #
   Two weeks ago I had an opportunity to architect and deploy a cluster of self-provisioning Docker Swarm servers, which utilised Consul as their shared database. Thanks to Consul, we could immediately identify the address and services running on any container in the cluster. This technology was remarkably easy to deploy. In fact, the biggest challenge was getting an understanding of how all the different pieces fit together. What we really needed was an `educational-scifi-adventure` movie to help educate everyone on these amazing tools. After all, we all know how warp drive and death stars work, and it’s that kind of knowledge that can only be taught through movies.
 ---

--- a/_posts/2015-07-09-whats-this-docker-thing.markdown
+++ b/_posts/2015-07-09-whats-this-docker-thing.markdown
@@ -10,6 +10,8 @@ tags:
   - Cloud
 author: Peter Viertel
 images: blog/whats-this-docker-thing.png
+thumbnail: blog/whats-this-docker-thing.png
+
 excerpt:
   If there’s one thing industry news sources have been mentioning to you recently it would almost certainly be Docker. But is there too much hype? Should one wait before looking into it?. There’s certainly a large amount of hype out there in the industry of the likes we have not seen since for about 6 years, when you could not move for “Cloud Experts” crowding your doorstep offering cloud this and cloud that. We can see with the benefit of hindsight that “The Cloud” did not turn out to be complete fakery, in fact it’s turned out a lot of the promises came true, it’s even better than expected in that “The Cloud” is now a whole industry that enhances and supports your operations, and you really can run your IT operations more efficiently.
 ---

--- a/_posts/2015-09-06-Is-the-EC2-Container-Service-a-bad-idea.markdown
+++ b/_posts/2015-09-06-Is-the-EC2-Container-Service-a-bad-idea.markdown
@@ -12,6 +12,8 @@ tags:
   - ECS
 author: Michael Richardson
 images: blog/is-this-ec2-thing-a-bad-idea.png
+thumbnail: blog/is-this-ec2-thing-a-bad-idea.png
+
 excerpt: The container revolutionaries call upon you! Are you ready to beg forgiveness for your sins of monolithic architecture and pay homage at the Church of 12 Factors? // No doubt you – like so many others before you – have endured the experience of being cornered by a zealot of the new world order. He is determined to make you see the light, and understand that containerisation is the future, and all ye who resist shall suffer the perpetual horrors of vertical scaling and, gasp, eternal re-architecture for multiple platforms.// Okay, I might be being a wee bit dramatic here. But you see, I too am a convert. I too carry around a copy of the Mesos white paper and dream of the swarm.
 ---
 

--- a/_posts/2015-09-28-My-DevOps-Journey.markdown
+++ b/_posts/2015-09-28-My-DevOps-Journey.markdown
@@ -11,7 +11,9 @@ tags:
   - Continuous Delivery
 author: Orlando Erazo
 images: blog/my-devops-journey.png
-excerpt: 
+thumbnail: blog/my-devops-journey.png
+
+excerpt:
   One of the challenges we devops Consultants face is explaining what we do to customers, as there are so many definitions. I’m always thinking about new ways to share the incredible opportunities that a continuous delivery pipeline offers.
 ---
 One of the challenges we devops Consultants face is explaining what we do to customers, as there are so many definitions. I’m always thinking about new ways to share the incredible opportunities that a continuous delivery pipeline offers. **So what is devops, and why does it matter?** The very definition of devops, as a portmanteau of Development and Operations suggests to us that this is a new role where we have to be fluent in both of these areas. But that’s a bit misleading. devops is not a role, a job description, or a single school of thought. Devops is a practice, a culture, and a movement. It is a different view of the Development Pipeline that involves much more than just Development and Operations. I like to think that devops as an extension of Agile. We have seen during the last 10 years or so a growing trend for companies to improve the way software is built by applying known and proven manufacturing concepts. Yes, manufacturing concepts! It seems an unlikely source but things like Lean Manufacturing have contributed a great deal to the software development space. With these progressive improvements in the development of software, organisations have started to face challenges also improving the delivery of software. This is the opportunity I see with devops; it compliments excellent software development with autonomous software delivery. **Where to Start?** I should start by mentioning that there are a lot of devops tools these days and the list keeps growing. Before you go into solution mode and try to automate software delivery, I strongly suggest that you take your time to evaluate your readiness to implement a devops approach, this is what it has worked for me.

--- a/_posts/2015-12-09-automated-provisioning-with-docker.markdown
+++ b/_posts/2015-12-09-automated-provisioning-with-docker.markdown
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Automated provisioning with Docker"
-description: How Media Links deployed Docker clusters to easily provision & scale their infrastructure 
+description: How Media Links deployed Docker clusters to easily provision & scale their infrastructure
 date:   2015-12-09
 categories:
   - devops
@@ -10,6 +10,7 @@ tags:
   - automation
 author: Eloise Skella
 images: blog/automated-provisioning-with-docker.png
+thumbnail: blog/automated-provisioning-with-docker.png
 ---
 
 #### Customer Overview

--- a/_posts/2016-08-08-migrating-to-aws.markdown
+++ b/_posts/2016-08-08-migrating-to-aws.markdown
@@ -9,6 +9,7 @@ tags:
   - aws
 author: Hannah Browne
 images: blog/migrating-to-aws.png
+thumbnail: blog/migrating-to-aws.png
 ---
 
 #### Customer Overview
@@ -16,14 +17,14 @@ MYOB is a leading provider of business management solutions in Australia and New
 
 #### Business Situation
 MYOB had a contract with its traditional Australian data centre due for renewal in early 2016. This provided the organisations with an opportunity to innovate and seek out infrastructure improvements to provide delivery teams more control of their environments. The vision was to reduce the cycle time of “concepts to production” through gaining configuration traceability, repeatability through automation and self service to reduce dependency on third parties. This vision ultimately tied into one of MYOB’s core business values to help businesses (their customers) be successful. “We needed a solution that would enable greater flexibility and visibility in terms of infrastructure configuration, automation and performance” says Grant Tibbey, Infrastructure Lead.   
-In its current state, MYOB Essentials was running in a third-party data center, utilising SQL Server and a Java front end. The company decided to move its infrastructure to AWS. 
+In its current state, MYOB Essentials was running in a third-party data center, utilising SQL Server and a Java front end. The company decided to move its infrastructure to AWS.
 
 
 #### Solution
 
 From the time MYOB decided it wanted more flexibility and more customer benefits from the Essentials infrastructure (until the existing contract expired), it had only approximately three months to complete the cutover.  
 
-MYOB formed a team using existing in house DevOps skills but didn’t have enough capacity to meet the aggressive deadlines. MYOB utilises a wide range of technologies, and Cevo were able to offer skills and availability with minimal onboarding requirements. MYOB was looking for experience without having to bring additional people up to speed on tools and techniques that were being applied to automation. 
+MYOB formed a team using existing in house DevOps skills but didn’t have enough capacity to meet the aggressive deadlines. MYOB utilises a wide range of technologies, and Cevo were able to offer skills and availability with minimal onboarding requirements. MYOB was looking for experience without having to bring additional people up to speed on tools and techniques that were being applied to automation.
 
 The existing application had some automation around building and deploying to the application servers using Ansible and Gradle. There was however no automation around building MS SQL Server and no automation around building the network infrastructure. Given the time constraints, existing automation was re-used and augmented with additional tools. Chef was chosen because of its ability to configure Windows and Linux servers securely using Secure WinRM and SSH protocols. It also gave the team the ability to unit and integration test components of the server automation as isolated modules and provided rapid feedback to the development processes using KitchenCI (test-kitchen). Unlike other automation technologies code could be developed and tested with the physical server being stubbed. This reduced server development wait-times. CloudFormation was used for network automation and enhanced with complex logic for alarm calculations using ruby code. CloudFormation templates were generated using a ruby gem “cfndsl” to enhance its static nature.   
 
@@ -36,7 +37,7 @@ Moving forward, the company plans to re-engineer the application from statically
 
 #### Benefits
 
-Benefits of the solution include providing MYOB with: 
+Benefits of the solution include providing MYOB with:
 
 * A safe, repeatable and easy means to release features to their customers as soon as they are capable of providing benefit.
 * The ability to rebuild servers at will or when they fail.

--- a/_posts/2016-08-12-Census-2.0.markdown
+++ b/_posts/2016-08-12-Census-2.0.markdown
@@ -10,6 +10,7 @@ tags:
   - System Architecture
 author: Steve Mactaggart
 images: blog/census-2.0.png
+thumbnail: blog/census-2.0.png
 excerpt:
   In light of the <a href="https://twitter.com/hashtag/CensusFAIL">#CensusFail</a> the ABS delivered to us on Tuesday night, I thought I'd put a blog post where my mouth is and suggest an architecture I feel would have delivered had Cevo been involved in the creation of this years' Census application.
 ---

--- a/_posts/2016-08-19-girls-in-tech.markdown
+++ b/_posts/2016-08-19-girls-in-tech.markdown
@@ -7,6 +7,7 @@ categories:
   - Community
 author: Hannah Browne
 images: blog/girls-in-tech.png
+thumbnail: blog/girls-in-tech.png
 excerpt:
   On August 10th Cevo's Hannah Browne joined Miguel Wood, Nicola Hazell and Geoff Gourley at daring discussion hosted by Girls in Tech Australia about diversity in technology.
 ---

--- a/_posts/2016-10-27-Patrick-Debois-Explains.markdown
+++ b/_posts/2016-10-27-Patrick-Debois-Explains.markdown
@@ -6,6 +6,7 @@ categories:
   - Community
 author: Team Cevo
 images: blog/what-is-devops.png
+thumbnail: blog/what-is-devops.png
 excerpt:
     DevOpsDays founder Patrick Debois explains his thoughts on what DevOps has become since defining the term in 2009.
 ---

--- a/_posts/2016-11-24-Enterprise-AWS.md
+++ b/_posts/2016-11-24-Enterprise-AWS.md
@@ -7,6 +7,7 @@ categories:
   - Enterprise
 author: Steve Mactaggart
 images: blog/enterprise-aws.png
+thumbnail: blog/enterprise-aws.png
 excerpt:
     As more enterprise scale businesses migrate their workloads to AWS, the size and complexity of the solutions they are trying to manage is growing.
 

--- a/_posts/2016-11-27-mapping-system-coupling.markdown
+++ b/_posts/2016-11-27-mapping-system-coupling.markdown
@@ -13,6 +13,8 @@ tags:
     - discovery
 author: Colin Panisset
 images: blog/mapping-systems-blog.png
+thumbnail: blog/mapping-systems-blog.png
+
 excerpt:
     Have you ever wondered just what would break if _that system_ (you know the one) went down?  Do you actually _know_ what systems depend on it? How do the reports get from it to Marketing? In this post, I'll describe a simple technique I've developed to surface and share all this juicy, interesting information.
 ---
@@ -97,7 +99,7 @@ There are 4 stages:
 
 1. Using Your Favourite Directed Graph Mapping Software (I like
    [GraphViz](http://graphviz.org) and my examples will use it),
-   turn the whiteboard scrawl into a directed graph of nodes and edges. 
+   turn the whiteboard scrawl into a directed graph of nodes and edges.
 1. Apply colours and annotations to the nodes and edges to distinguish
    types of nodes (databases, humans, etc) and types of edges (HTTP,
    SQL, email, USB stick, etc)
@@ -117,7 +119,7 @@ There are 4 stages:
    how you capture the "oh, I just remembered" and the "I was too
    ashamed to say it before" details. A measure of both anonymity and
    time-dependent opportunity is at work here.
-1. Before the map becomes illegible from updates, take it off the wall 
+1. Before the map becomes illegible from updates, take it off the wall
    and capture the changes in the map source code (version-controlled,
    of course, so you can illustrate changes over time)
 1. Print it out again, stick it up, and repeat until the rate of change
@@ -217,4 +219,3 @@ perhaps you simply don't have time or capacity to do the mapping yourself;
 or perhaps you've mapped your system thoroughly, and want some help
 untangling it. In any of these cases, if you're looking for a team who've
 Been There and Seen That, and made it better, please give us a call!
-

--- a/_posts/2017-01-18-youre-doing-it-wrong-if.markdown
+++ b/_posts/2017-01-18-youre-doing-it-wrong-if.markdown
@@ -10,6 +10,7 @@ tags:
     - best-practice
 author: Steve Mactaggart
 images: blog/youre-doing-it-wrong-if.png
+thumbnail: blog/youre-doing-it-wrong-if.png
 
 excerpt:
     We are all looking to learn from our failures and make things better, but sometimes it better to communicate what is right by eliminating what is wrong.<br/>

--- a/_posts/2017-02-23-a-spot-of-aws.markdown
+++ b/_posts/2017-02-23-a-spot-of-aws.markdown
@@ -10,6 +10,7 @@ tags:
     - cost
 author: Henrik Axelsson
 images: blog/a-spot-of-aws.png
+thumbnail: blog/a-spot-of-aws.png
 
 excerpt:
     Have you considered using spot instances to save on AWS costs? It may pay to investigate the details of your operating environment first!

--- a/_posts/2017-02-28-DevOpsDays2016.markdown
+++ b/_posts/2017-02-28-DevOpsDays2016.markdown
@@ -10,6 +10,7 @@ tags:
     - video
 author: Team Cevo
 images: blog/why-the-forgotten-word.png
+thumbnail: blog/why-the-forgotten-word.png
 
 excerpt:
     From DevOpsDays 2016 our own Hannah Browne and Steve Mactaggart explore why we do what we do.<br/>

--- a/_posts/2017-03-12-four-values-of-devops.markdown
+++ b/_posts/2017-03-12-four-values-of-devops.markdown
@@ -9,6 +9,7 @@ tags:
     - devops
 author: Steve Mactaggart
 images: blog/the-four-values-of-a-devops-transformation.png
+thumbnail: blog/the-four-values-of-a-devops-transformation.png
 
 excerpt:
     Just like the agile transformations of the past, there is a difference between ‘Doing Agile’, and ‘Being Agile’.  ‘We do standups’ - therefore we are Agile. With the increase in adoption of devops practices, are we 'Doing devops' or are we 'Being devops'?


### PR DESCRIPTION
If there is a `thumbnail` field on the post, then use the image and share it as a `summary_large_image` otherwise just use the swoosh as a `summary`.

Had to hard code the site.url in the `_config.yaml` file, which will break links between beta/www.

Also looks like images are re-gen'd each time not sure if that will effect any deep link issues.