### PR TITLE
adding a way to crosspost to Medium

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ gem "jekyll-assets"
 gem "jekyll-sitemap"
 gem 'jekyll-compose', group: [:jekyll_plugins]
 
+gem 'jekyll-crosspost-to-medium'
+
 gem "rest-client"
 
 gem "sass"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
       sprockets (~> 3.3, < 3.8)
     jekyll-compose (0.5.0)
       jekyll (>= 3.0.0)
+    jekyll-crosspost-to-medium (0.1.14)
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (1.5.0)
       sass (~> 3.4)
@@ -105,6 +106,7 @@ DEPENDENCIES
   jekyll
   jekyll-assets
   jekyll-compose
+  jekyll-crosspost-to-medium
   jekyll-paginate
   jekyll-sitemap
   mini_magick

--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ careers:
 include: [robots.txt]
 exclude: [Gemfile, Gemfile.lock, README.md, TODO.md, .dockerignore, install_image_optim.sh]
 markdown: kramdown
-plugins: [jekyll-paginate, jekyll-assets, jekyll-sitemap]
+plugins: [jekyll-paginate, jekyll-assets, jekyll-sitemap, jekyll-crosspost-to-medium]
 paginate: 4
 paginate_path: "blog/page:num"
 future: true
@@ -48,3 +48,4 @@ assets:
     - _assets/css
     - _assets/javascripts
     - _assets/images
+

--- a/_config_beta.yml
+++ b/_config_beta.yml
@@ -2,3 +2,5 @@ url: "http://beta.cevo.com.au" # the base hostname & protocol for your site
 robots:
   allow: "Disallow: /"
 
+jekyll-crosspost_to_medium:
+  enabled: true

--- a/_config_production.yml
+++ b/_config_production.yml
@@ -2,3 +2,5 @@ url: "https://www.cevo.com.au" # the base hostname & protocol for your site
 robots:
   allow: "Allow: /"
 
+jekyll-crosspost_to_medium:
+  enabled: true

--- a/_posts/2017-08-05-greenfields-tech-decisions.markdown
+++ b/_posts/2017-08-05-greenfields-tech-decisions.markdown
@@ -12,6 +12,7 @@ tags:
     - leadership
 author: Trent Hornibrook
 images:
+crosspost_to_medium: true
 
 excerpt:
     You are given a blank cheque at a start-up and you need to execute on a product strategy. What technical choices would you make?.

--- a/_posts/2017-08-24-devops-and-empathy.markdown
+++ b/_posts/2017-08-24-devops-and-empathy.markdown
@@ -10,6 +10,7 @@ tags:
     - devops
 author: Trent Hornibrook
 images:
+crosspost_to_medium: true
 
 excerpt:
     Trent Hornibrook recently gave a DevOps brownbag at a client where he described the DevOps transformation of REA Group and his perspective on DevOps.


### PR DESCRIPTION
This uses
https://github.com/aarongustafson/jekyll-crosspost-to-medium


This is what we need:
1. A "Cevo" Medium branded account - we need someone with the Twitter account to sign up with it.
2. Agreement on where we put the environment variables of the configuration of
`MEDIUM_USER_ID` and `MEDIUM_INTEGRATION_TOKEN` for that account. 

Regarding (2) - I think I'd want Codeship to do that - Does Codeship have any elegant support here? (I dont have access to the Codeship account)


Here is an example of a crosspost: https://medium.com/@trent.hornibrook/devops-agile-organisational-structure-and-empathy-4781e5550d3 