### PR TITLE
add a light-blue background to posts that are in draft mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ TRAVIS_BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
 
 ifeq ($(TRAVIS_BRANCH),develop)
         BASE_URL=http://beta.cevo.com.au/
+        BUILD_DRAFTS="--buildDrafts"
 endif
 
 ifeq ($(TRAVIS_BRANCH),master)
@@ -10,10 +11,10 @@ ifeq ($(TRAVIS_BRANCH),master)
 endif
 
 run:
-	@hugo serve --baseUrl $(BASE_URL)
+	hugo serve --baseUrl $(BASE_URL) ${BUILD_DRAFTS}
 
 build:
-	@hugo --baseUrl $(BASE_URL)
+	hugo --baseUrl $(BASE_URL) ${BUILD_DRAFTS}
 
 default: build
 

--- a/layouts/post/content-list.html
+++ b/layouts/post/content-list.html
@@ -1,11 +1,14 @@
+{{ if .Params.draft }}
+<article class="post draft">
+{{ else }}
 <article class="post">
+{{ end }}
     {{ .Render "header" }}
     {{ if .Params.excerpt }}
         <p>{{ printf "%s" .Params.excerpt | markdownify }}</p>
     {{ else }}
         <p>{{ printf "%s" .Summary | markdownify }}</p>
     {{ end }}
-
     <footer>
         <ul class="actions">
             <li><a href="{{ .Permalink }}" class="button big">Continue Reading</a></li>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -8,8 +8,11 @@
     {{ partial "nav" . }}
 
     <div class="container">
+      {{ if .Params.draft }}
+      <article class="post draft">
+      {{ else }}
       <article class="post">
-
+      {{ end }}
         {{ $.Scratch.Set "h1" true }}
         {{ .Render "header" }}
         {{ .Render "feature-img" }}

--- a/static/css/post.css
+++ b/static/css/post.css
@@ -8,6 +8,10 @@
 		margin-top: 40px;
 	}
 
+	.draft {
+		background-color: lightblue;
+	}
+
 		.post > header {
 			display: -moz-flex;
 			display: -webkit-flex;


### PR DESCRIPTION
If a post has the parameter "draft: true" set, then it will appear with a light-blue background.
Like so on the content-list: 
![content-list](https://user-images.githubusercontent.com/6980747/35080394-640e348a-fc61-11e7-934b-acc4f15d6b8b.png)

and in the post itself:
![single](https://user-images.githubusercontent.com/6980747/35080422-931c42f8-fc61-11e7-9436-9c7cd4667fe2.png)

