### PR TITLE
generate anchors for case studies from title or use from params

### DIFF
--- a/content/case-study/Catch-web-outage.md
+++ b/content/case-study/Catch-web-outage.md
@@ -5,7 +5,7 @@ clientLink: "#"
 cases: engineering
 img: CatchIcon.png
 banner: catchCS.png
-
+anchor: case-study-4
 ---
 # Industry
 

--- a/content/case-study/MYOB-migrate.md
+++ b/content/case-study/MYOB-migrate.md
@@ -5,6 +5,7 @@ clientLink: "#"
 cases: devops
 img: myob.png
 banner: myob-migrate-case-study2.png
+anchor: case-study-3
 
 ---
 # Industry

--- a/content/case-study/iag-security.md
+++ b/content/case-study/iag-security.md
@@ -5,6 +5,7 @@ clientLink: "#"
 cases: cloud
 img: iag.png
 banner: IAG-Watchmen.png
+anchor: case-study-6
 ---
 # Industry
 

--- a/layouts/case-study/content-list.html
+++ b/layouts/case-study/content-list.html
@@ -1,7 +1,11 @@
 
 <div class="col-md-4 col-sm-6 case-flex-item">
   <div class="portfolio-item">
-    <a href="#case-study-{{ .Scratch.Get "index" }}" class="portfolio-link" data-toggle="modal">
+    {{ if .Params.anchor }}
+      <a href="#{{ .Params.anchor }}" class="portfolio-link" data-toggle="modal">
+    {{ else }}
+      <a href="#case-study-{{ urlize .Params.title }}" class="portfolio-link" data-toggle="modal">
+    {{ end }}
       <div class="portfolio-hover">
         <div class="portfolio-hover-content">
         </div>

--- a/layouts/case-study/content-modal.html
+++ b/layouts/case-study/content-modal.html
@@ -1,4 +1,8 @@
-<div class="portfolio-modal modal fade" id="case-study-{{ .Scratch.Get "index" }}" tabindex="-1" role="dialog" aria-hidden="true">
+{{ if .Params.anchor }}
+  <div class="portfolio-modal modal fade" id="{{ .Params.anchor }}" tabindex="-1" role="dialog" aria-hidden="true">
+{{ else }}
+  <div class="portfolio-modal modal fade" id="case-study-{{ urlize .Params.title }}" tabindex="-1" role="dialog" aria-hidden="true">
+{{ end }}
   <div class="modal-content">
     <div class="close-modal" data-dismiss="modal">
       <div class="lr">

--- a/layouts/case-study/list.html
+++ b/layouts/case-study/list.html
@@ -16,8 +16,7 @@
         </div>
         <div class="case-flex-row row">
 
-          {{ range $i, $s := .Data.Pages }}
-              {{ .Scratch.Set "index" $i }}
+          {{ range .Data.Pages }}
               {{ .Render "content-list" }}
           {{ end }}
 
@@ -25,8 +24,7 @@
       </div>
     </section>
 
-    {{ range $i, $s := .Data.Pages }}
-        {{ .Scratch.Set "index" $i }}
+    {{ range .Data.Pages }}
         {{ .Render "content-modal" }}
     {{ end }}
 


### PR DESCRIPTION
Fixes #242

Backward compatibility with already announced urls via `anchor` optional property.